### PR TITLE
Refactor: antd Message 헤더에 중앙화

### DIFF
--- a/src/components/Common/DeleteDialog.tsx
+++ b/src/components/Common/DeleteDialog.tsx
@@ -11,10 +11,10 @@ import { useCallback, useRef } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 import { useMutation, useQueryClient } from 'react-query';
 import { deleteTask } from '@/api/Project/Task.ts';
-import { useMessage } from '@/hooks/useMessage.ts';
 import { taskAll } from '@/recoil/Project/Task.ts';
-import { useRecoilValue } from 'recoil';
+import { useRecoilState, useRecoilValue } from 'recoil';
 import { deletePost } from '@/api/Project/Post.ts';
+import { message } from '@/recoil/Common/atom.ts';
 
 interface Props {
   isOpen: boolean;
@@ -28,7 +28,7 @@ interface Props {
 export default function DeleteDialog({ isOpen, onClose, task, post, menuId, isTask }: Props) {
   const cancelRef = useRef<HTMLButtonElement>(null);
   const { product, project, menutitle } = useParams();
-  const { showMessage, contextHolder } = useMessage();
+  const [messageInfo, setMessageInfo] = useRecoilState(message);
   const taskList = useRecoilValue(taskAll);
   const navigate = useNavigate();
   const queryClient = useQueryClient();
@@ -49,11 +49,11 @@ export default function DeleteDialog({ isOpen, onClose, task, post, menuId, isTa
     },
     onSuccess: (data) => {
       if (data === 'delete task fail') {
-        showMessage('error', 'Task 삭제에 실패했습니다.');
+        setMessageInfo({ type: 'error', content: 'Task 삭제에 실패했습니다.' });
       } else if (typeof data !== 'string' && 'message' in data) {
-        showMessage('error', 'Task 삭제에 실패했습니다.');
+        setMessageInfo({ type: 'error', content: 'Task 삭제에 실패했습니다.' });
       } else if (data === 'delete') {
-        showMessage('success', 'Task가 삭제되었습니다.');
+        setMessageInfo({ type: 'success', content: 'Task가 삭제되었습니다.' });
         setTimeout(() => {
           onClose();
           navigate(`/workspace/${product}/${project}/menu/${menutitle}`);
@@ -63,9 +63,9 @@ export default function DeleteDialog({ isOpen, onClose, task, post, menuId, isTa
     onError: (error, value, rollback) => {
       if (rollback) {
         rollback();
-        showMessage('error', 'Task 삭제에 실패했습니다.');
+        setMessageInfo({ type: 'error', content: 'Task 삭제에 실패했습니다.' });
       } else {
-        showMessage('error', 'Task 삭제에 실패했습니다.');
+        setMessageInfo({ type: 'error', content: 'Task 삭제에 실패했습니다.' });
       }
     },
     onSettled: () => {
@@ -87,11 +87,11 @@ export default function DeleteDialog({ isOpen, onClose, task, post, menuId, isTa
     },
     onSuccess: (data) => {
       if (data === 'delete post fail') {
-        showMessage('error', 'Post 삭제에 실패했습니다.');
+        setMessageInfo({ type: 'error', content: 'Post 삭제에 실패했습니다.' });
       } else if (typeof data !== 'string' && 'message' in data) {
-        showMessage('error', 'Post 삭제에 실패했습니다.');
+        setMessageInfo({ type: 'error', content: 'Post 삭제에 실패했습니다.' });
       } else if (data === 'delete 완료') {
-        showMessage('success', 'Post가 삭제되었습니다.');
+        setMessageInfo({ type: 'success', content: 'Post가 삭제되었습니다.' });
         setTimeout(() => {
           onClose();
           navigate(`/workspace/${product}/${project}/menu/${menutitle}`);
@@ -101,9 +101,9 @@ export default function DeleteDialog({ isOpen, onClose, task, post, menuId, isTa
     onError: (error, value, rollback) => {
       if (rollback) {
         rollback();
-        showMessage('error', 'Post 삭제에 실패했습니다.');
+        setMessageInfo({ type: 'error', content: 'Post 삭제에 실패했습니다.' });
       } else {
-        showMessage('error', 'Post 삭제에 실패했습니다.');
+        setMessageInfo({ type: 'error', content: 'Post 삭제에 실패했습니다.' });
       }
     },
     onSettled: () => {
@@ -128,7 +128,6 @@ export default function DeleteDialog({ isOpen, onClose, task, post, menuId, isTa
       onClose={onClose}
       isCentered={true}
     >
-      {contextHolder}
       <AlertDialogOverlay>
         <AlertDialogContent maxW={'30rem'}>
           <AlertDialogHeader bgColor={'var(--white)'} color={'var(--black)'}>

--- a/src/components/Member/MyPage/UserManageModal.tsx
+++ b/src/components/Member/MyPage/UserManageModal.tsx
@@ -17,16 +17,21 @@ import { useMutation } from 'react-query';
 import { changePassword, deleteAccount } from '@/api/Members/mypage.ts';
 import { SaveUserInfo } from '@/typings/member.ts';
 import { loginStatus } from '@/recoil/User/atom.ts';
-import { useSetRecoilState } from 'recoil';
+import { SetterOrUpdater, useSetRecoilState } from 'recoil';
 import { useCookies } from 'react-cookie';
 
 interface Props {
   isOpen: boolean;
   onClose: () => void;
   isClickPwChange: boolean;
-  showMessage: (type: MessageType, content: string) => void;
+  setMessageInfo: SetterOrUpdater<{ type: MessageType; content: string } | null>;
 }
-export default function UserManageModal({ isOpen, onClose, isClickPwChange, showMessage }: Props) {
+export default function UserManageModal({
+  isOpen,
+  onClose,
+  isClickPwChange,
+  setMessageInfo,
+}: Props) {
   const userInfo: SaveUserInfo = JSON.parse(sessionStorage.getItem('userInfo')!);
   const [password, onChangePassword, setPassword] = useInput('');
   const [newPassword, onChangeNewPassword, setNewPassword] = useInput('');
@@ -45,22 +50,22 @@ export default function UserManageModal({ isOpen, onClose, isClickPwChange, show
   const { mutate: changePasswordMutate } = useMutation(changePassword, {
     onSuccess: (data) => {
       if (data && 'message' in data) {
-        showMessage('warning', '현재 비밀번호가 일치하지 않습니다.');
+        setMessageInfo({ type: 'warning', content: '현재 비밀번호가 일치하지 않습니다.' });
         return;
       }
 
       resetPw();
-      showMessage('success', '비밀번호 변경 완료!');
+      setMessageInfo({ type: 'success', content: '비밀번호 변경 완료!' });
     },
     onError: () => {
-      showMessage('error', '다시 시도해주세요.');
+      setMessageInfo({ type: 'error', content: '다시 시도해주세요.' });
     },
   });
 
   const { mutate: deleteAccountMutate } = useMutation(deleteAccount, {
     onSuccess: (data) => {
       if (typeof data !== 'string') {
-        showMessage('warning', data.message);
+        setMessageInfo({ type: 'warning', content: data.message });
         return;
       }
 
@@ -73,18 +78,18 @@ export default function UserManageModal({ isOpen, onClose, isClickPwChange, show
       navigator('/');
     },
     onError: () => {
-      showMessage('error', '다시 시도해주세요.');
+      setMessageInfo({ type: 'error', content: '다시 시도해주세요.' });
     },
   });
 
   const onClickChangePassword = useCallback(() => {
     if (!password || !newPassword) {
-      showMessage('warning', '비밀번호를 입력해주세요.');
+      setMessageInfo({ type: 'warning', content: '비밀번호를 입력해주세요.' });
       return;
     }
 
     if (!isCheckPw) {
-      showMessage('warning', '올바른 새로운 비밀번호를 입력해주세요.');
+      setMessageInfo({ type: 'warning', content: '올바른 새로운 비밀번호를 입력해주세요.' });
       return;
     }
 
@@ -93,7 +98,7 @@ export default function UserManageModal({ isOpen, onClose, isClickPwChange, show
 
   const onClickDeleteAccount = useCallback(() => {
     if (!password) {
-      showMessage('warning', '비밀번호를 입력해주세요.');
+      setMessageInfo({ type: 'warning', content: '비밀번호를 입력해주세요.' });
       return;
     }
 

--- a/src/components/Product/Members/AuthorityModal.tsx
+++ b/src/components/Product/Members/AuthorityModal.tsx
@@ -10,7 +10,7 @@ import {
   Select,
 } from '@chakra-ui/react';
 import { productMemberList } from '@/recoil/Product/atom.ts';
-import { useRecoilState } from 'recoil';
+import { SetterOrUpdater, useRecoilState } from 'recoil';
 import { AiFillCaretDown } from 'react-icons/ai';
 type MessageType = 'success' | 'error' | 'warning';
 
@@ -20,7 +20,7 @@ interface Props {
   onClickChangeRoleLeader: (memberId: number) => void;
   onClickChangeRoleDefault: (memberId: number) => void;
   nowSelectedMemberId: number;
-  showMessage: (type: MessageType, content: string) => void;
+  setMessageInfo: SetterOrUpdater<{ type: MessageType; content: string } | null>;
 }
 
 export default function AuthorityModal({
@@ -29,7 +29,7 @@ export default function AuthorityModal({
   onClickChangeRoleLeader,
   onClickChangeRoleDefault,
   nowSelectedMemberId,
-  showMessage,
+  setMessageInfo,
 }: Props) {
   const [members, setMembers] = useRecoilState(productMemberList);
   const [selectedMember, setSelectedMember] = useState('-1');
@@ -109,7 +109,7 @@ export default function AuthorityModal({
                 onChangeLeader();
               }, 500);
               onClose();
-              showMessage('success', '권한이 변경되었습니다.');
+              setMessageInfo({ type: 'success', content: '권한이 변경되었습니다.' });
             }}
           >
             완료

--- a/src/components/Product/Members/MemberListManageAlert.tsx
+++ b/src/components/Product/Members/MemberListManageAlert.tsx
@@ -8,6 +8,7 @@ import {
   AlertDialogOverlay,
   Button,
 } from '@chakra-ui/react';
+import { SetterOrUpdater } from 'recoil';
 type MessageType = 'success' | 'error' | 'warning';
 
 interface Props {
@@ -17,7 +18,7 @@ interface Props {
   nickName: string;
   onClickChangeRoleLeader: (memberId: number) => void;
   nowSelectedMemberId: number;
-  showMessage: (type: MessageType, content: string) => void;
+  setMessageInfo: SetterOrUpdater<{ type: MessageType; content: string } | null>;
 }
 export default function MemberListManageAlert({
   isOut,
@@ -26,14 +27,14 @@ export default function MemberListManageAlert({
   nickName,
   onClickChangeRoleLeader,
   nowSelectedMemberId,
-  showMessage,
+  setMessageInfo,
 }: Props) {
   const cancelRef = useRef<HTMLButtonElement>(null);
 
   const onClickChange = useCallback(() => {
     onClickChangeRoleLeader(nowSelectedMemberId);
     onClose();
-    showMessage('success', '권한이 변경되었습니다.');
+    setMessageInfo({ type: 'success', content: '권한이 변경되었습니다.' });
   }, [nowSelectedMemberId]);
 
   return (

--- a/src/components/Product/ReleaseNote/ProjectModal.tsx
+++ b/src/components/Product/ReleaseNote/ProjectModal.tsx
@@ -16,7 +16,7 @@ import { completeProject, createProject } from '@/api/Project/Version.ts';
 import { useMutation, useQueryClient } from 'react-query';
 import { ProductInfo } from '@/typings/product.ts';
 import { eachProductProjects } from '@/recoil/Project/atom.ts';
-import { useRecoilState, useRecoilValue } from 'recoil';
+import { SetterOrUpdater, useRecoilState, useRecoilValue } from 'recoil';
 import { Release } from '@/typings/project.ts';
 import { frontEndUrl } from '@/recoil/Common/atom.ts';
 type MessageType = 'success' | 'error' | 'warning';
@@ -26,7 +26,7 @@ interface Props {
   onClose: () => void;
   isAdd: boolean;
   versionName: string;
-  showMessage: (type: MessageType, content: string) => void;
+  setMessageInfo: SetterOrUpdater<{ type: MessageType; content: string } | null>;
   nowProjectId: number;
 }
 export default function ProjectModal({
@@ -34,7 +34,7 @@ export default function ProjectModal({
   onClose,
   isAdd,
   versionName,
-  showMessage,
+  setMessageInfo,
   nowProjectId,
 }: Props) {
   const nowProduct: ProductInfo = JSON.parse(sessionStorage.getItem('nowProduct')!);
@@ -50,11 +50,11 @@ export default function ProjectModal({
     onSuccess: (data) => {
       if (typeof data !== 'string' && 'id' in data) {
         newProjectId.current = data.id;
-        showMessage('success', '프로젝트가 생성되었습니다!');
+        setMessageInfo({ type: 'success', content: '프로젝트가 생성되었습니다!' });
       } else if (typeof data !== 'string' && 'message' in data) {
-        showMessage('warning', '진행 중인 프로젝트가 있습니다.');
+        setMessageInfo({ type: 'warning', content: '진행 중인 프로젝트가 있습니다.' });
       } else {
-        showMessage('error', '프로젝트 생성에 실패하였습니다.');
+        setMessageInfo({ type: 'error', content: '프로젝트 생성에 실패하였습니다.' });
       }
     },
     onMutate: async ({ version }) => {
@@ -116,7 +116,7 @@ export default function ProjectModal({
 
   const onClickCreateProject = useCallback(() => {
     if (projects.some((project) => project.version === text)) {
-      showMessage('error', '이미 존재하는 버전입니다!');
+      setMessageInfo({ type: 'error', content: '이미 존재하는 버전입니다!' });
       return;
     }
 
@@ -131,7 +131,7 @@ export default function ProjectModal({
 
   const onClickCompleteProject = useCallback(() => {
     if (projects.some((project) => project.version === text)) {
-      showMessage('error', '이미 존재하는 버전입니다!');
+      setMessageInfo({ type: 'error', content: '이미 존재하는 버전입니다!' });
       return;
     }
 
@@ -139,7 +139,7 @@ export default function ProjectModal({
       projectId: nowProjectId === -1 ? newProjectId.current : nowProjectId,
       version: text,
     });
-    showMessage('success', '프로젝트 완료!');
+    setMessageInfo({ type: 'success', content: '프로젝트 완료!' });
     onClose();
     setText('');
   }, [text, newProjectId]);

--- a/src/components/Product/SideBar/CreateGroupModal.tsx
+++ b/src/components/Product/SideBar/CreateGroupModal.tsx
@@ -17,17 +17,18 @@ import { useGetProductMembers } from '@/pages/Product/hooks/useGetProductMembers
 import { AiOutlinePlus } from 'react-icons/ai';
 import { Scrollbars } from 'react-custom-scrollbars';
 import { convertNumberArrayToStringArray } from '@/utils/convertNumberArrayToStringArray.ts';
+import { SetterOrUpdater } from 'recoil';
 type MessageType = 'success' | 'error' | 'warning';
 
 interface Props {
   isOpen: boolean;
   onClose: () => void;
-  showMessage: (type: MessageType, content: string) => void;
+  setMessageInfo: SetterOrUpdater<{ type: MessageType; content: string } | null>;
   parentGroups: ParentGroupWithStates[];
   setParentGroups: Dispatch<SetStateAction<ParentGroupWithStates[]>>;
 }
 
-export default function CreateGroupModal({ isOpen, onClose, showMessage, parentGroups }: Props) {
+export default function CreateGroupModal({ isOpen, onClose, setMessageInfo, parentGroups }: Props) {
   // TODO: 그룹 이름 중복 안되게 해야됨
   const [groupName, onChangeGroupName, setGroupName] = useInput('');
   const [isClickMemberList, setIsClickMemberList] = useState(false);
@@ -81,13 +82,13 @@ export default function CreateGroupModal({ isOpen, onClose, showMessage, parentG
   } = useMutation(createProjectTeam, {
     onSuccess: (data) => {
       if (typeof data === 'string' && data === '프로젝트 내에서 팀 이름이 중복됩니다.') {
-        showMessage('warning', '프로젝트 내에서 팀 이름이 중복됩니다.');
+        setMessageInfo({ type: 'warning', content: '프로젝트 내에서 팀 이름이 중복됩니다.' });
         return;
       } else if (typeof data !== 'string') {
         onClose();
         setInviteMembers([]);
         setGroupName('');
-        showMessage('success', '그룹이 생성되었습니다.');
+        setMessageInfo({ type: 'success', content: '그룹이 생성되었습니다.' });
       }
     },
     onMutate: async () => {
@@ -119,7 +120,7 @@ export default function CreateGroupModal({ isOpen, onClose, showMessage, parentG
 
   const onClickCreate = useCallback(() => {
     if (groupName === '') {
-      showMessage('warning', '그룹 이름을 입력해주세요.');
+      setMessageInfo({ type: 'warning', content: '그룹 이름을 입력해주세요.' });
       return;
     }
 

--- a/src/components/Product/SideBar/Groups.tsx
+++ b/src/components/Product/SideBar/Groups.tsx
@@ -1,17 +1,16 @@
-import React, { useCallback, useEffect, useLayoutEffect, useRef, useState } from 'react';
+import React, { useCallback, useEffect, useState } from 'react';
 import { AiOutlinePlus } from 'react-icons/ai';
 import { Collapse, useDisclosure } from '@chakra-ui/react';
 import { BsDot } from 'react-icons/bs';
 import { NavLink, useLocation, useNavigate, useParams } from 'react-router-dom';
 import { IoIosArrowDown, IoMdSettings } from 'react-icons/io';
 import CreateGroupModal from '@/components/Product/SideBar/CreateGroupModal.tsx';
-import { ChildGroup, ChildTeamInfoDTO, ParentGroupWithStates, Project } from '@/typings/project.ts';
-import { useMessage } from '@/hooks/useMessage.ts';
+import { ChildTeamInfoDTO, ParentGroupWithStates, Project } from '@/typings/project.ts';
 import { useGetProjectGroups } from '@/components/Project/hooks/useGetProjectGroups.ts';
-import { useMutation } from '@tanstack/react-query';
 import { useQuery } from 'react-query';
 import { getChildGroups } from '@/api/Project/Version.ts';
-import useInput from '@/hooks/useInput.ts';
+import { message } from '@/recoil/Common/atom.ts';
+import { useRecoilState } from 'recoil';
 
 export default function Groups() {
   const { product, project, parentgroup, childgroup } = useParams();
@@ -19,7 +18,7 @@ export default function Groups() {
   const navigate = useNavigate();
   const { pathname } = useLocation();
   const nowProject: Project = JSON.parse(sessionStorage.getItem('nowProject')!);
-  const { showMessage, contextHolder } = useMessage();
+  const [messageInfo, setMessageInfo] = useRecoilState(message);
   const [parentGroups, setParentGroups] = useState<ParentGroupWithStates[]>([]);
   const [nowParentGroupId, setNowParentGroupId] = useState(-1);
   const [nowParentGroupIdx, setNowParentGroupIdx] = useState(-1);
@@ -115,7 +114,7 @@ export default function Groups() {
 
   useEffect(() => {
     if (typeof getChildGroup !== 'string' && getChildGroup?.childTeamInfoDTOList.length === 0) {
-      showMessage('warning', '하위 그룹이 없습니다!');
+      setMessageInfo({ type: 'warning', content: '하위 그룹이 없습니다!' });
 
       const temp = [...parentGroups];
       temp[nowParentGroupIdx]['isOpen'] = false;
@@ -125,7 +124,6 @@ export default function Groups() {
 
   return (
     <section className={'px-10'}>
-      {contextHolder}
       <div className={'h-20 flex-row-center justify-between'}>
         <header className={'text-[1.4rem] font-bold'}>Group</header>
         {/* 그룹 최대 개수 30갸 */}
@@ -223,7 +221,7 @@ export default function Groups() {
       <CreateGroupModal
         isOpen={isOpen}
         onClose={onClose}
-        showMessage={showMessage}
+        setMessageInfo={setMessageInfo}
         parentGroups={parentGroups}
         setParentGroups={setParentGroups}
       />

--- a/src/components/Product/hooks/useGetEachProduct.ts
+++ b/src/components/Product/hooks/useGetEachProduct.ts
@@ -2,19 +2,20 @@ import { eachProduct } from '@/api/Product/Product.ts';
 import { useQuery } from 'react-query';
 import { Dispatch, SetStateAction } from 'react';
 import { ProductsData } from '@/typings/product.ts';
+import { SetterOrUpdater } from 'recoil';
 
 type MessageType = 'success' | 'error' | 'warning';
 
 export function useGetEachProduct(
   productId: number,
-  showMessage: (type: MessageType, content: string) => void,
+  setMessageInfo: SetterOrUpdater<{ type: MessageType; content: string } | null>,
   setProductName?: Dispatch<SetStateAction<string>>,
   isEnabled = true
 ): [ProductsData | [], () => void] {
   const { refetch, data } = useQuery(['getProjectInfo', productId], () => eachProduct(productId), {
     onSuccess: (data) => {
       if (typeof data === 'object' && 'message' in data) {
-        showMessage('error', '제품 정보를 불러오는데 실패했습니다.');
+        setMessageInfo({ type: 'error', content: '제품 정보를 불러오는데 실패했습니다.' });
       } else if (typeof data !== 'string' && 'name' in data && setProductName) {
         setProductName(data.name);
       }

--- a/src/components/Project/Board/StatusBoard.tsx
+++ b/src/components/Project/Board/StatusBoard.tsx
@@ -1,13 +1,12 @@
 import { TaskData, TaskStatus } from '@/typings/task.ts';
-import { GoKebabHorizontal } from 'react-icons/go';
 import { FaUserCircle } from 'react-icons/fa';
 import { useState } from 'react';
 import { formatStatus } from '@/utils/formatStatus.ts';
 import { Draggable, Droppable } from 'react-beautiful-dnd';
 import { useLocation, useNavigate } from 'react-router-dom';
-import { useMessage } from '@/hooks/useMessage.ts';
-import { setClipBoardUrl } from '@/utils/setClipBoardUrl.ts';
 import { Scrollbars } from 'rc-scrollbars';
+import { message } from '@/recoil/Common/atom.ts';
+import { useRecoilState } from 'recoil';
 
 interface Props {
   status: TaskStatus;
@@ -16,7 +15,7 @@ interface Props {
 export default function StatusBoard({ status, tasks }: Props) {
   const convertStatus = formatStatus(status);
   const navigate = useNavigate();
-  const { showMessage, contextHolder } = useMessage();
+  const [messageInfo, setMessageInfo] = useRecoilState(message);
   // task detail 클릭 여부
   const [isClickTaskDetail, setIsClickTaskDetail] = useState<{ [key: number]: boolean }>({});
 
@@ -26,10 +25,10 @@ export default function StatusBoard({ status, tasks }: Props) {
   // const handleCopyClipBoard = async (task: TaskData) => {
   //   try {
   //     await navigator.clipboard?.writeText(setClipBoardUrl(task, location.pathname));
-  //     showMessage('success', '링크가 복사되었습니다.');
+  //     setMessageInfo({ type: 'success', content: '링크가 복사되었습니다.' });
   //   } catch (error) {
   //     console.log(error);
-  //     showMessage('error', '링크복사에 실패했습니다.');
+  //     setMessageInfo({ type: 'error', content: '링크복사에 실패했습니다.' });
   //   }
   // };
 
@@ -43,7 +42,6 @@ export default function StatusBoard({ status, tasks }: Props) {
           ref={provided.innerRef}
           {...provided.droppableProps}
         >
-          {contextHolder}
           {/*제목, 개수*/}
           <div
             className={

--- a/src/components/Project/Menu/DeleteMenuDialog.tsx
+++ b/src/components/Project/Menu/DeleteMenuDialog.tsx
@@ -13,9 +13,8 @@ import { useRecoilState } from 'recoil';
 import { useNavigate, useParams } from 'react-router-dom';
 import { deleteMenu } from '@/api/Project/Menu.ts';
 import { useMutation, useQueryClient } from 'react-query';
-import { useMessage } from '@/hooks/useMessage.ts';
-import { SaveUserInfo } from '@/typings/member.ts';
 import { SaveProjectInfo } from '@/typings/project.ts';
+import { message } from '@/recoil/Common/atom.ts';
 
 interface Props {
   isOpen: boolean;
@@ -26,7 +25,7 @@ interface Props {
 export default function DeleteMenuDialog({ isOpen, onClose, menu, menuId }: Props) {
   const { product, project } = useParams();
   const navigate = useNavigate();
-  const { showMessage, contextHolder } = useMessage();
+  const [messageInfo, setMessageInfo] = useRecoilState(message);
   const cancelRef = useRef<HTMLButtonElement>(null);
   const [menuList, setMenuList] = useRecoilState(menuListData);
   const queryClient = useQueryClient();
@@ -55,10 +54,10 @@ export default function DeleteMenuDialog({ isOpen, onClose, menu, menuId }: Prop
     },
     onSuccess: (data) => {
       if (data === 'delete menu fail') {
-        showMessage('error', '메뉴 삭제에 실패했습니다.');
+        setMessageInfo({ type: 'error', content: '메뉴 삭제에 실패했습니다.' });
         setTimeout(() => onClose(), 2000);
       } else if (data === 'delete') {
-        showMessage('success', '해당 메뉴가 삭제되었습니다.');
+        setMessageInfo({ type: 'success', content: '해당 메뉴가 삭제되었습니다.' });
         setTimeout(() => onClose(), 2000);
       }
     },
@@ -66,9 +65,9 @@ export default function DeleteMenuDialog({ isOpen, onClose, menu, menuId }: Prop
       // rollback은 onMutate의 return값
       if (rollback) {
         rollback();
-        showMessage('error', '메뉴 삭제에 실패했습니다.');
+        setMessageInfo({ type: 'error', content: '메뉴 삭제에 실패했습니다.' });
       } else {
-        showMessage('error', '메뉴 삭제에  실패했습니다.');
+        setMessageInfo({ type: 'error', content: '메뉴 삭제에  실패했습니다.' });
       }
     },
     onSettled: () => {
@@ -92,7 +91,6 @@ export default function DeleteMenuDialog({ isOpen, onClose, menu, menuId }: Prop
       onClose={onClose}
       isCentered={true}
     >
-      {contextHolder}
       <AlertDialogOverlay>
         <AlertDialogContent maxW={'30rem'}>
           <AlertDialogHeader bgColor={'var(--white)'} color={'var(--black)'}>

--- a/src/components/Project/Menu/MenuSlider.tsx
+++ b/src/components/Project/Menu/MenuSlider.tsx
@@ -9,14 +9,13 @@ import { Editable, EditableInput, EditablePreview, useDisclosure } from '@chakra
 import { useRecoilState } from 'recoil';
 import { menuListData } from '@/recoil/Project/Menu.ts';
 import { useCallback, useState } from 'react';
-import { useMessage } from '@/hooks/useMessage.ts';
 import DeleteMenuDialog from '@/components/Project/Menu/DeleteMenuDialog.tsx';
 import { useMutation, useQueryClient } from 'react-query';
 import { createMenu, editMenu } from '@/api/Project/Menu.ts';
 import { FailMenu, MenuInfo } from '@/typings/menu.ts';
 import { useGetMenuList } from '@/components/Project/hooks/useGetMenuList.ts';
 import { SaveProjectInfo } from '@/typings/project.ts';
-import { ProductInfo } from '@/typings/product.ts';
+import { message } from '@/recoil/Common/atom.ts';
 
 interface Props {
   product: string;
@@ -43,7 +42,7 @@ const CustomNextSlider = styled.div`
 `;
 
 export default function MenuSlider({ product, project, menutitle }: Props) {
-  const { showMessage, contextHolder } = useMessage();
+  const [messageInfo, setMessageInfo] = useRecoilState(message);
 
   const [menuList, setMenuList] = useRecoilState(menuListData);
   const [plusMenu, setPlusMenu] = useState(false);
@@ -68,11 +67,11 @@ export default function MenuSlider({ product, project, menutitle }: Props) {
     {
       onSuccess: (data: FailMenu | MenuInfo | string) => {
         if (typeof data === 'object' && 'message' in data) {
-          showMessage('error', data.message);
+          setMessageInfo({ type: 'error', content: data.message });
         } else if (data === 'success') {
-          showMessage('success', '메뉴가 생성되었습니다.');
+          setMessageInfo({ type: 'success', content: '메뉴가 생성되었습니다.' });
         } else {
-          showMessage('error', '메뉴 생성에 실패하였습니다.');
+          setMessageInfo({ type: 'error', content: '메뉴 생성에 실패하였습니다.' });
         }
       },
       onSettled: () => {
@@ -86,9 +85,9 @@ export default function MenuSlider({ product, project, menutitle }: Props) {
   const { mutate: editMenuMutate } = useMutation((newName: string) => editMenu(menuId, newName), {
     onSuccess: (data) => {
       if (data === 'success') {
-        showMessage('success', '메뉴 이름이 변경되었습니다.');
+        setMessageInfo({ type: 'success', content: '메뉴 이름이 변경되었습니다.' });
       } else {
-        showMessage('error', '메뉴 이름 변경에 실패하였습니다.');
+        setMessageInfo({ type: 'error', content: '메뉴 이름 변경에 실패하였습니다.' });
       }
     },
     onSettled: () => {
@@ -111,7 +110,7 @@ export default function MenuSlider({ product, project, menutitle }: Props) {
     (menuId: number) => (nextValue: string) => {
       // 빈 문자열인 경우
       if (editMenuName === '') {
-        showMessage('warning', '메뉴 이름을 입력해주세요.');
+        setMessageInfo({ type: 'warning', content: '메뉴 이름을 입력해주세요.' });
         // 바뀐 menuName에 맞게 주소값도 다시 설정
         navigate(`/workspace/${product}/${project}/menu/menu${menuId}`);
         // menu edit api 요청
@@ -121,7 +120,7 @@ export default function MenuSlider({ product, project, menutitle }: Props) {
 
       const checkDuplicate = menuList.some((menu) => menu.menuName === nextValue);
       if (checkDuplicate) {
-        showMessage('warning', '중복된 메뉴 이름입니다.');
+        setMessageInfo({ type: 'warning', content: '중복된 메뉴 이름입니다.' });
 
         const updatedMenuList = menuList.map((menu) =>
           menu.id === menuId ? { ...menu, menuName: nextValue } : menu
@@ -149,7 +148,7 @@ export default function MenuSlider({ product, project, menutitle }: Props) {
 
       // 특수문자는 불가
       // if (!regex.test(nextValue)) {
-      //   showMessage('warning', '메뉴 이름은 한글, 영문만 가능합니다.');
+      // setMessageInfo({ type: 'warning', content: '메뉴 이름은 한글, 영문만 가능합니다.' });
       //   setPlusMenu(false);
       //   return;
       // }
@@ -219,7 +218,6 @@ export default function MenuSlider({ product, project, menutitle }: Props) {
             }
             key={menu.id}
           >
-            {contextHolder}
             {menutitle === menu.menuName && menu.menuName !== '결과물' && (
               <IoIosClose
                 className={

--- a/src/components/Project/Post/PostComment.tsx
+++ b/src/components/Project/Post/PostComment.tsx
@@ -10,9 +10,10 @@ import {
   updateComment,
 } from '@/api/Project/Post.ts';
 import { CommentBody, CommentInfo } from '@/typings/post.ts';
-import { useMessage } from '@/hooks/useMessage.ts';
 import { SaveUserInfo } from '@/typings/member.ts';
 import { SaveProjectInfo } from '@/typings/project.ts';
+import { message } from '@/recoil/Common/atom.ts';
+import { useRecoilState } from 'recoil';
 
 interface Props {
   postId: number;
@@ -20,7 +21,7 @@ interface Props {
 }
 
 export default function PostComment({ postId, menuId }: Props) {
-  const { showMessage, contextHolder } = useMessage();
+  const [messageInfo, setMessageInfo] = useRecoilState(message);
   const userInfo: SaveUserInfo = JSON.parse(sessionStorage.getItem('userInfo')!);
   const nowProject: SaveProjectInfo = JSON.parse(sessionStorage.getItem('nowProject')!);
 
@@ -68,17 +69,17 @@ export default function PostComment({ postId, menuId }: Props) {
     },
     onSuccess: (data) => {
       if (typeof data !== 'string' && 'message' in data) {
-        showMessage('warning', data.message);
+        setMessageInfo({ type: 'warning', content: data.message });
       } else if (data === 'success') {
-        showMessage('success', '댓글이 등록되었습니다.');
-      } else showMessage('error', '댓글 등록에 실패했습니다.');
+        setMessageInfo({ type: 'success', content: '댓글이 등록되었습니다.' });
+      } else setMessageInfo({ type: 'error', content: '댓글 등록에 실패했습니다.' });
     },
     onError: (error, value, rollback) => {
       if (rollback) {
         rollback();
-        showMessage('error', '댓글 등록에 실패했습니다.');
+        setMessageInfo({ type: 'error', content: '댓글 등록에 실패했습니다.' });
       } else {
-        showMessage('error', '댓글 등록에 실패했습니다.');
+        setMessageInfo({ type: 'error', content: '댓글 등록에 실패했습니다.' });
       }
     },
     onSettled: () => {
@@ -106,15 +107,15 @@ export default function PostComment({ postId, menuId }: Props) {
       },
       onSuccess: (data) => {
         if (typeof data === 'string' && data === 'DELETE OK') {
-          showMessage('success', '댓글이 삭제되었습니다.');
+          setMessageInfo({ type: 'success', content: '댓글이 삭제되었습니다.' });
         }
       },
       onError: (error, value, rollback) => {
         if (rollback) {
           rollback();
-          showMessage('error', '댓글 삭제에 실패했습니다.');
+          setMessageInfo({ type: 'error', content: '댓글 삭제에 실패했습니다.' });
         } else {
-          showMessage('error', '댓글 삭제에 실패했습니다.');
+          setMessageInfo({ type: 'error', content: '댓글 삭제에 실패했습니다.' });
         }
       },
       onSettled: () => {
@@ -129,9 +130,9 @@ export default function PostComment({ postId, menuId }: Props) {
   //   onSuccess: (data) => {
   //     if (typeof data !== 'string' && 'cnt' in data) {
   //       if (commentLikeData.some((like) => like.id === commentId)) {
-  //         showMessage('success', '🥲🥲');
+  //         setMessageInfo('success', '🥲🥲');
   //       } else {
-  //         showMessage('success', '😍️😍');
+  //         setMessageInfo('success', '😍️😍');
   //       }
   //     }
   //   },
@@ -227,7 +228,7 @@ export default function PostComment({ postId, menuId }: Props) {
   useEffect(() => {
     if (check) {
       if (createData.content === '') {
-        showMessage('warning', '댓글을 입력해주세요.');
+        setMessageInfo({ type: 'warning', content: '댓글을 입력해주세요.' });
         return;
       }
 
@@ -243,7 +244,6 @@ export default function PostComment({ postId, menuId }: Props) {
 
   return (
     <div className={'flex-col-center justify-start w-[60%] h-auto'}>
-      {contextHolder}
       {/*댓글 */}
       {commentList !== undefined &&
         Array.from(commentList)

--- a/src/components/Project/Post/PostEach.tsx
+++ b/src/components/Project/Post/PostEach.tsx
@@ -12,10 +12,11 @@ import { useDisclosure } from '@chakra-ui/react';
 import { Viewer } from '@toast-ui/react-editor';
 import { useMutation, useQuery, useQueryClient } from 'react-query';
 import { noticePost, postLike, postLikeCount, unNoticePost } from '@/api/Project/Post.ts';
-import { useMessage } from '@/hooks/useMessage.ts';
 import { SaveUserInfo } from '@/typings/member.ts';
 import { ProductInfo } from '@/typings/product.ts';
 import { SaveProjectInfo } from '@/typings/project.ts';
+import { message } from '@/recoil/Common/atom.ts';
+import { useRecoilState } from 'recoil';
 
 interface Props {
   post: Post;
@@ -24,7 +25,7 @@ interface Props {
   noticeId?: number;
 }
 export default function PostEach({ post, menuId, likeList, noticeId }: Props) {
-  const { showMessage, contextHolder } = useMessage();
+  const [messageInfo, setMessageInfo] = useRecoilState(message);
   const productInfo: ProductInfo = JSON.parse(sessionStorage.getItem('nowProduct')!);
   const nowProject: SaveProjectInfo = JSON.parse(sessionStorage.getItem('nowProject')!);
 
@@ -43,8 +44,8 @@ export default function PostEach({ post, menuId, likeList, noticeId }: Props) {
   const { mutate: noticePostMutate } = useMutation(() => noticePost(menuId, post.id), {
     onSuccess: (data) => {
       if (typeof data !== 'string' && 'id' in data) {
-        showMessage('success', '공지글로 등록되었습니다.');
-      } else showMessage('error', '공지글 등록에 실패했습니다.');
+        setMessageInfo({ type: 'success', content: '공지글로 등록되었습니다.' });
+      } else setMessageInfo({ type: 'error', content: '공지글 등록에 실패했습니다.' });
     },
     onSettled: () => {
       return queryClient.invalidateQueries(['menuPostData', menuId], { refetchInactive: true });
@@ -55,8 +56,8 @@ export default function PostEach({ post, menuId, likeList, noticeId }: Props) {
   const { mutate: unNoticePostMutate } = useMutation(() => unNoticePost(menuId), {
     onSuccess: (data) => {
       if (data === 'delete') {
-        showMessage('success', '공지글이 해제 되었습니다.');
-      } else showMessage('error', '공지글 해제에 실패했습니다.');
+        setMessageInfo({ type: 'success', content: '공지글이 해제 되었습니다.' });
+      } else setMessageInfo({ type: 'error', content: '공지글 해제에 실패했습니다.' });
     },
     onSettled: () => {
       return queryClient.invalidateQueries(['menuPostData', menuId], { refetchInactive: true });
@@ -77,14 +78,14 @@ export default function PostEach({ post, menuId, likeList, noticeId }: Props) {
     onSuccess: (data) => {
       if (typeof data !== 'string' && 'cnt' in data) {
         if (likeList.some((likePost) => likePost.id === post.id)) {
-          showMessage('success', '🥲🥲');
+          setMessageInfo({ type: 'success', content: '🥲🥲' });
         } else {
-          showMessage('success', '😍️😍');
+          setMessageInfo({ type: 'success', content: '😍️😍' });
         }
       } else if (typeof data !== 'string' && 'message' in data) {
-        showMessage('warning', data.message);
+        setMessageInfo({ type: 'warning', content: data.message });
       } else {
-        showMessage('error', '좋아요 실패');
+        setMessageInfo({ type: 'error', content: '좋아요 실패' });
       }
     },
     onSettled: () => {
@@ -132,7 +133,6 @@ export default function PostEach({ post, menuId, likeList, noticeId }: Props) {
         'flex-col-center justify-start w-full h-auto border border-line bg-post-bg py-[1.8rem] px-[3.3rem] mb-12'
       }
     >
-      {contextHolder}
       {/*작성자 정보 + 작성일자 시간*/}
       <div className={'flex-row-center justify-start w-full h-[5.8rem]'}>
         {post.authorInfoDTO.image ? (

--- a/src/components/Project/Post/PostModal.tsx
+++ b/src/components/Project/Post/PostModal.tsx
@@ -8,7 +8,6 @@ import {
   ModalHeader,
   ModalOverlay,
 } from '@chakra-ui/react';
-import { useMessage } from '@/hooks/useMessage.ts';
 import useInput from '@/hooks/useInput.ts';
 import { Select } from 'antd';
 import { menuListData } from '@/recoil/Project/Menu.ts';
@@ -18,7 +17,7 @@ import { useRecoilState, useRecoilValue } from 'recoil';
 import { useCallback, useEffect, useLayoutEffect, useState } from 'react';
 import PostEditor from '@/components/Common/PostEditor.tsx';
 import TagInput from '@/components/Project/Post/TagInput.tsx';
-import { editorPost, themeState } from '@/recoil/Common/atom.ts';
+import { editorPost, message, themeState } from '@/recoil/Common/atom.ts';
 import { useMutation, useQuery, useQueryClient } from 'react-query';
 import { createPost, eachPost, updatePost } from '@/api/Project/Post.ts';
 import { useParams } from 'react-router-dom';
@@ -35,7 +34,7 @@ interface Props {
 
 export default function PostModal({ isOpen, onClose, post, isEdit }: Props) {
   const { product, project, menutitle } = useParams();
-  const { showMessage, contextHolder } = useMessage();
+  const [messageInfo, setMessageInfo] = useRecoilState(message);
   const productInfo: ProductInfo = JSON.parse(sessionStorage.getItem('nowProduct')!);
   const nowProject: SaveProjectInfo = JSON.parse(sessionStorage.getItem('nowProject')!);
   const projectId = nowProject.id;
@@ -106,17 +105,17 @@ export default function PostModal({ isOpen, onClose, post, isEdit }: Props) {
     },
     onSuccess: (data) => {
       if (data === 'success') {
-        showMessage('success', 'Post 생성에 성공했습니다.');
+        setMessageInfo({ type: 'success', content: 'Post 생성에 성공했습니다.' });
       } else if (typeof data !== 'string' && 'message' in data) {
-        showMessage('warning', data.message);
-      } else showMessage('error', 'Post 생성에 실패했습니다.');
+        setMessageInfo({ type: 'warning', content: data.message });
+      } else setMessageInfo({ type: 'error', content: 'Post 생성에 실패했습니다.' });
     },
     onError: (error, newData, rollback) => {
       if (rollback) {
         rollback();
-        showMessage('error', 'Post 생성에 실패했습니다.');
+        setMessageInfo({ type: 'error', content: 'Post 생성에 실패했습니다.' });
       } else {
-        showMessage('error', 'Post 생성에 실패했습니다.');
+        setMessageInfo({ type: 'error', content: 'Post 생성에 실패했습니다.' });
       }
     },
     onSettled: () => {
@@ -155,17 +154,17 @@ export default function PostModal({ isOpen, onClose, post, isEdit }: Props) {
       },
       onSuccess: (data) => {
         if (data === 'success') {
-          showMessage('success', 'Post 수정에 성공했습니다.');
+          setMessageInfo({ type: 'success', content: 'Post 수정에 성공했습니다.' });
         } else if (typeof data !== 'string' && 'message' in data) {
-          showMessage('warning', data.message);
-        } else showMessage('error', 'Post 수정에 실패했습니다.');
+          setMessageInfo({ type: 'warning', content: data.message });
+        } else setMessageInfo({ type: 'error', content: 'Post 수정에 실패했습니다.' });
       },
       onError: (error, newData, rollback) => {
         if (rollback) {
           rollback();
-          showMessage('error', 'Post 수정에 실패했습니다.');
+          setMessageInfo({ type: 'error', content: 'Post 수정에 실패했습니다.' });
         } else {
-          showMessage('error', 'Post 수정에 실패했습니다.');
+          setMessageInfo({ type: 'error', content: 'Post 수정에 실패했습니다.' });
         }
       },
       onSettled: () => {
@@ -192,12 +191,12 @@ export default function PostModal({ isOpen, onClose, post, isEdit }: Props) {
   const handleFinishClick = useCallback(() => {
     // 빈 값이 있는지 예외처리
     if (postName === '') {
-      showMessage('warning', 'Post 제목을 입력해주세요.');
+      setMessageInfo({ type: 'warning', content: 'Post 제목을 입력해주세요.' });
       return;
     }
 
     if (postMenu === -1) {
-      showMessage('warning', '메뉴를 선택해주세요.');
+      setMessageInfo({ type: 'warning', content: '메뉴를 선택해주세요.' });
       return;
     }
 
@@ -285,7 +284,6 @@ export default function PostModal({ isOpen, onClose, post, isEdit }: Props) {
 
   return (
     <Modal isCentered onClose={onClose} isOpen={isOpen}>
-      {contextHolder}
       <ModalOverlay />
       <ModalContent
         minW="65rem"

--- a/src/components/Project/Post/TagInput.tsx
+++ b/src/components/Project/Post/TagInput.tsx
@@ -1,11 +1,11 @@
 import { useState } from 'react';
 import { TiDelete } from 'react-icons/ti';
-import { useMessage } from '@/hooks/useMessage.ts';
 import { useRecoilState } from 'recoil';
 import { postTagList } from '@/recoil/Project/Post.ts';
+import { message } from '@/recoil/Common/atom.ts';
 
 export default function TagInput() {
-  const { showMessage, contextHolder } = useMessage();
+  const [messageInfo, setMessageInfo] = useRecoilState(message);
   const [tagItem, setTagItem] = useState('');
   const [tagList, setTagList] = useRecoilState(postTagList);
 
@@ -17,7 +17,7 @@ export default function TagInput() {
     if (e.key === 'Enter') {
       // tagList가 10개 이상일 경우 추가 안됨
       if (tagList.length >= 10) {
-        showMessage('error', '태그는 10개까지만 입력 가능합니다.');
+        setMessageInfo({ type: 'error', content: '태그는 10개까지만 입력 가능합니다.' });
         return;
       }
       submitTagItem();
@@ -44,7 +44,6 @@ export default function TagInput() {
 
   return (
     <div className={'flex-row-center flex-wrap justify-start w-[80%] h-auto '}>
-      {contextHolder}
       {tagList.map((tagItem, index) => {
         return (
           <div

--- a/src/components/Project/Task/CreateTask.tsx
+++ b/src/components/Project/Task/CreateTask.tsx
@@ -9,13 +9,12 @@ import {
   ModalOverlay,
   Textarea,
 } from '@chakra-ui/react';
-import { useMessage } from '@/hooks/useMessage.ts';
 import useInput from '@/hooks/useInput.ts';
 import { Project, SubGroup } from '@/typings/project.ts';
 import { SelectMenu } from '@/typings/menu.ts';
 import { DatePicker, DatePickerProps, Select } from 'antd';
 import { ChangeEvent, useCallback, useEffect, useState } from 'react';
-import { useRecoilValue } from 'recoil';
+import { useRecoilState, useRecoilValue } from 'recoil';
 import { menuListData } from '@/recoil/Project/Menu.ts';
 import { allMemberList, productMemberList } from '@/recoil/Product/atom.ts';
 import { TaskBody, TaskData } from '@/typings/task.ts';
@@ -24,6 +23,7 @@ import { createTask } from '@/api/Project/Task.ts';
 import { RangePickerProps } from 'antd/es/date-picker';
 import dayjs from 'dayjs';
 import { ProductInfo, ProductMember } from '@/typings/product.ts';
+import { message } from '@/recoil/Common/atom.ts';
 
 interface Props {
   isOpen: boolean;
@@ -31,7 +31,7 @@ interface Props {
   menuId: number;
 }
 export default function CreateTask({ isOpen, onClose, menuId }: Props) {
-  const { showMessage, contextHolder } = useMessage();
+  const [messageInfo, setMessageInfo] = useRecoilState(message);
   const nowTeamId: number = JSON.parse(sessionStorage.getItem('nowTeamId')!);
   const nowProject: Project = JSON.parse(sessionStorage.getItem('nowProject')!);
 
@@ -103,11 +103,11 @@ export default function CreateTask({ isOpen, onClose, menuId }: Props) {
     },
     onSuccess: (data) => {
       if (typeof data === 'object' && 'message' in data) {
-        showMessage('error', data.message);
+        setMessageInfo('error', data.message);
       } else if (data === 'create task fail') {
-        showMessage('error', 'Task 생성에 실패했습니다.');
+        setMessageInfo({ type: 'error', content: 'Task 생성에 실패했습니다.' });
       } else {
-        showMessage('success', 'Task가 생성되었습니다.');
+        setMessageInfo({ type: 'success', content: 'Task가 생성되었습니다.' });
         setTimeout(() => onClose(), 2000);
       }
     },
@@ -115,9 +115,9 @@ export default function CreateTask({ isOpen, onClose, menuId }: Props) {
       // rollback은 onMutate의 return값
       if (rollback) {
         rollback();
-        showMessage('error', 'Task 생성에 실패했습니다.');
+        setMessageInfo({ type: 'error', content: 'Task 생성에 실패했습니다.' });
       } else {
-        showMessage('error', 'Task 생성에 실패했습니다.');
+        setMessageInfo({ type: 'error', content: 'Task 생성에 실패했습니다.' });
       }
     },
     onSettled: () => {
@@ -250,29 +250,29 @@ export default function CreateTask({ isOpen, onClose, menuId }: Props) {
   const onClickCreateTask = useCallback(() => {
     // 빈 값이 있는지 예외처리
     if (newTask.taskName === '') {
-      showMessage('warning', 'Task 이름을 입력해주세요.');
+      setMessageInfo({ type: 'warning', content: 'Task 이름을 입력해주세요.' });
       return;
     }
 
     if (newTask.startTime === '' || newTask.endTime === '') {
-      showMessage('warning', '날짜를 선택해주세요.');
+      setMessageInfo({ type: 'warning', content: '날짜를 선택해주세요.' });
       return;
     }
 
     // TODO : 그룹, 할당자 정보 가져오면 주석 다시 풀기
     // if (newTask.teamId === 0) {
-    //   showMessage('warning', '그룹을 선택해주세요.');
+    // setMessageInfo({ type: 'warning', content: '그룹을 선택해주세요.' });
     //   return;
     // }
 
     if (newTask.menuId === 0) {
-      showMessage('warning', '메뉴를 선택해주세요.');
+      setMessageInfo({ type: 'warning', content: '메뉴를 선택해주세요.' });
       return;
     }
 
     // TODO : 그룹, 할당자 정보 가져오면 주석 다시 풀기
     // if (newTask.targetMemberId === 0) {
-    //   showMessage('warning', '할당자를 선택해주세요.');
+    // setMessageInfo({ type: 'warning', content: '할당자를 선택해주세요.' });
     //   return;
     // }
 
@@ -347,8 +347,6 @@ export default function CreateTask({ isOpen, onClose, menuId }: Props) {
         <ModalBody>
           <Flex justifyContent={'center'} h={'100%'}>
             <section className={'flex-col-center justify-evenly w-[80%] h-full'}>
-              {contextHolder}
-
               {/*Task 정보 입력 -> 제목*/}
               <div className={'w-full mt-4 mb-5 text-[1rem]'}>
                 <div className={'flex'}>

--- a/src/components/UI/Header.tsx
+++ b/src/components/UI/Header.tsx
@@ -10,14 +10,18 @@ import { productOpen } from '@/recoil/Product/atom.ts';
 import { useOutsideAlerter } from '@/hooks/useOutsideAlerter.ts';
 import ProductList from '@/components/Product/Info/ProductList.tsx';
 import UserProfile from '@/components/Member/Header/UserProfile.tsx';
-import { themeState } from '@/recoil/Common/atom.ts';
+import { message, themeState } from '@/recoil/Common/atom.ts';
 import { ProductInfo } from '@/typings/product.ts';
 import { BiChevronDown } from 'react-icons/bi';
 import { useGetAllProduct } from '@/components/Product/hooks/useGetAllProduct.ts';
 import { SaveUserInfo } from '@/typings/member.ts';
 import { useQueryClient } from 'react-query';
+import { useMessage } from '@/hooks/useMessage.ts';
 
 export default function Header() {
+  const { showMessage, contextHolder } = useMessage();
+  const [messageInfo, setMessageInfo] = useRecoilState(message);
+
   const navigate = useNavigate();
   const [darkMode, setDarkMode] = useRecoilState(themeState);
   const nowProduct: ProductInfo = JSON.parse(sessionStorage.getItem('nowProduct')!);
@@ -104,6 +108,10 @@ export default function Header() {
     setUserInfo({ ...JSON.parse(sessionStorage.getItem('userInfo')!) });
   }, []);
 
+  useEffect(() => {
+    if (messageInfo !== null) showMessage(messageInfo.type, messageInfo.content);
+  }, [messageInfo]);
+
   return (
     <header
       className={`fixed top-0 flex-row-center justify-between pt-[0.5rem] w-full h-[5.7rem] z-50
@@ -113,6 +121,7 @@ export default function Header() {
           : 'border-solid border-b border-header-gray'
       }`}
     >
+      {contextHolder}
       {/*로고 + 글자 (메인페이지로 이동)*/}
       <div
         className={'relative flex-row-center justify-start w-[60%] h-full md:w-auto ml-12 md:ml-12'}

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -3,16 +3,15 @@ import { BsArrowRightShort } from 'react-icons/bs';
 import { useNavigate } from 'react-router-dom';
 import { loginStatus } from '@/recoil/User/atom.ts';
 import { useRecoilState } from 'recoil';
-import { useMessage } from '@/hooks/useMessage.ts';
+import { message } from '@/recoil/Common/atom.ts';
 
 export default function Home() {
   const navigate = useNavigate();
   const [isLogin, setIsLogin] = useRecoilState(loginStatus);
-  const { showMessage, contextHolder } = useMessage();
+  const [messageInfo, setMessageInfo] = useRecoilState(message);
 
   return (
     <section className={'flex-col-center justify-start w-h-full min-w-[30em]'}>
-      {contextHolder}
       <div className={'flex-col w-full h-[55%] pt-[8%]'}>
         <div className={'flex-col-center font-logo font-bold text-[5.5rem]'}>
           <div className={'flex-row-center'}>
@@ -43,7 +42,9 @@ export default function Home() {
             'flex-row-center justify-between w-[30rem] h-[6.5rem] pl-28 pr-8 cursor-pointer rounded-xl bg-orange font-logo font-bold shadow-[0_4px_9px_-4px_#e4a11b] transition duration-150 ease-in-out hover:shadow-[0_8px_9px_-4px_rgba(228,161,27,0.3),0_4px_18px_0_rgba(228,161,27,0.2)] hover:scale-110 hover:bg-[#F86F03] focus:shadow-[0_8px_9px_-4px_rgba(228,161,27,0.3),0_4px_18px_0_rgba(228,161,27,0.2)] focus:outline-none focus:ring-0 active:bg-warning-700 active:shadow-[0_8px_9px_-4px_rgba(228,161,27,0.3),0_4px_18px_0_rgba(228,161,27,0.2)] hover:text-white'
           }
           onClick={() => {
-            isLogin ? showMessage('warning', '제품을 만들어 주세요!') : navigate('/login');
+            isLogin
+              ? setMessageInfo({ type: 'warning', content: '제품을 만들어 주세요!' })
+              : navigate('/login');
           }}
         >
           <span className={'mt-4 text-[2.5rem]'}>Get Started&nbsp;!</span>

--- a/src/pages/Member/Login.tsx
+++ b/src/pages/Member/Login.tsx
@@ -4,7 +4,6 @@ import useInput from '@/hooks/useInput.ts';
 import { AiOutlineLock } from 'react-icons/ai';
 import { Link, useNavigate } from 'react-router-dom';
 import { useGoogleLogin } from '@react-oauth/google';
-import { useMessage } from '@/hooks/useMessage.ts';
 import { GetUserInfo, LoginInfo, SaveUserInfo } from '@/typings/member.ts';
 import { useMutation } from 'react-query';
 import { useRecoilState } from 'recoil';
@@ -12,9 +11,11 @@ import { loginStatus, user } from '@/recoil/User/atom.ts';
 import { useCookies } from 'react-cookie';
 import { loginAPI } from '@/api/Members/Login-Signup.ts';
 import { sendLog } from '@/api/Log';
+import { message } from '@/recoil/Common/atom.ts';
 
 export default function Login() {
-  const { showMessage, contextHolder } = useMessage();
+  const [messageInfo, setMessageInfo] = useRecoilState(message);
+
   const [email, onChangeEmail, setEmail] = useInput('');
   const [password, onChangePassword, setPassword] = useInput('');
   const navigate = useNavigate();
@@ -25,7 +26,7 @@ export default function Login() {
   const { mutate, isSuccess } = useMutation(loginAPI, {
     onSuccess: (data: GetUserInfo | string) => {
       if (typeof data === 'string') {
-        showMessage('error', '아이디 또는 비밀번호를 잘못 입력하셨습니다.');
+        setMessageInfo({ type: 'error', content: '아이디 또는 비밀번호를 잘못 입력하셨습니다.' });
         return;
       }
 
@@ -50,7 +51,7 @@ export default function Login() {
       navigate('/workspace/1', { state: { isLogin: true } });
     },
     onError: () => {
-      showMessage('error', '아이디 또는 비밀번호를 잘못 입력하셨습니다.');
+      setMessageInfo({ type: 'error', content: '아이디 또는 비밀번호를 잘못 입력하셨습니다.' });
       sendLogMutate({ page: 'login', status: false, message: 'login fail' });
     },
   });
@@ -62,21 +63,21 @@ export default function Login() {
       e.preventDefault();
 
       if (!email && !password) {
-        showMessage('warning', '이메일과 비밀번호를 입력해주세요.');
+        setMessageInfo({ type: 'warning', content: '이메일과 비밀번호를 입력해주세요.' });
         sendLogMutate({ page: 'login', status: false, message: 'all' });
 
         return;
       }
 
       if (!email) {
-        showMessage('warning', '이메일을 입력해주세요.');
+        setMessageInfo({ type: 'warning', content: '이메일을 입력해주세요.' });
         sendLogMutate({ page: 'login', status: false, message: 'email' });
 
         return;
       }
 
       if (!password) {
-        showMessage('warning', '비밀번호를 입력해주세요.');
+        setMessageInfo({ type: 'warning', content: '비밀번호를 입력해주세요.' });
         sendLogMutate({ page: 'login', status: false, message: 'password' });
 
         return;
@@ -101,7 +102,7 @@ export default function Login() {
 
   return (
     <section className={'h-full'}>
-      {contextHolder}
+      {/*{contextHolder}*/}
       <div className={'w-h-full flex-col-center'}>
         <article>
           <img className={'w-[5.7rem] h-[6.7rem]'} src={'logo.svg'} alt={'logo'} />

--- a/src/pages/Member/MyPage.tsx
+++ b/src/pages/Member/MyPage.tsx
@@ -10,20 +10,20 @@ import { SaveUserInfo } from '@/typings/member.ts';
 import useInput from '@/hooks/useInput.ts';
 import { useMutation } from 'react-query';
 import { changeName, changeNickname, imageUpload, updateMyInfo } from '@/api/Members/mypage.ts';
-import { useMessage } from '@/hooks/useMessage.ts';
 import { useRecoilState } from 'recoil';
 import { user } from '@/recoil/User/atom.ts';
+import { message } from '@/recoil/Common/atom.ts';
 
 export default function MyPage() {
   // const userInfo: SaveUserInfo = JSON.parse(sessionStorage.getItem('userInfo')!);
   const [userInfo, setUserInfo] = useRecoilState(user);
   const [newName, onChangeNewName, setNewName] = useInput('');
   const [newNickname, onChangeNewNickname, setNewNickname] = useInput('');
-  const { showMessage, contextHolder } = useMessage();
+  const [messageInfo, setMessageInfo] = useRecoilState(message);
 
   // const { mutate: nameChangeMutate } = useMutation(changeName, {
   //   onError: () => {
-  //     showMessage('error', '이름 변경 실패!');
+  // setMessageInfo({ type: 'error', content: '이름 변경 실패!' });
   //   },
   // });
   // const { mutate: nicknameChangeMutate } = useMutation(changeNickname);
@@ -59,7 +59,7 @@ export default function MyPage() {
     const imgChk = fileList?.[0]?.url === userInfo.image || fileList.length === 0;
 
     if (!newName && !newNickname && imgChk) {
-      showMessage('warning', '프로필 변경을 해주세요.');
+      setMessageInfo({ type: 'warning', content: '프로필 변경을 해주세요.' });
       return;
     }
 
@@ -96,7 +96,7 @@ export default function MyPage() {
 
     setNewNickname('');
     setNewName('');
-    showMessage('success', '프로필 변경 완료!');
+    setMessageInfo({ type: 'success', content: '프로필 변경 완료!' });
   }, [newName, newNickname, fileList, userInfo]);
 
   // 비밀번호 변경 모달
@@ -123,7 +123,6 @@ export default function MyPage() {
 
   return (
     <section className={'mypage flex flex-col items-center w-full h-[68rem]'}>
-      {contextHolder}
       <article className={'w-[46rem] h-[44rem] mt-12'}>
         <h1 className={'h-[10%] text-3xl font-bold'}>프로필 수정</h1>
         <div
@@ -242,7 +241,7 @@ export default function MyPage() {
         isOpen={isOpen}
         onClose={onClose}
         isClickPwChange={isClickPwChange}
-        showMessage={showMessage}
+        setMessageInfo={setMessageInfo}
       />
     </section>
   );

--- a/src/pages/Member/PwInquiry.tsx
+++ b/src/pages/Member/PwInquiry.tsx
@@ -1,16 +1,17 @@
 import React, { FormEvent, useCallback, useState } from 'react';
-import { useMessage } from '@/hooks/useMessage.ts';
 import { MdOutlineMailOutline } from 'react-icons/md';
 import useInput from '@/hooks/useInput.ts';
 import { useNavigate } from 'react-router-dom';
 import { useMutation } from 'react-query';
 import { emailRequest } from '@/api/Members/Login-Signup.ts';
+import { message } from '@/recoil/Common/atom.ts';
+import { useRecoilState } from 'recoil';
 
 export default function PwInquiry() {
   const navigate = useNavigate();
   const [email, onChangeEmail, setEmail] = useInput('');
   const [isSend, setIsSend] = useState(false);
-  const { showMessage, contextHolder } = useMessage();
+  const [messageInfo, setMessageInfo] = useRecoilState(message);
 
   const { mutate } = useMutation(emailRequest);
 
@@ -21,7 +22,7 @@ export default function PwInquiry() {
       if (!isSend) {
         const emailRegex = /^[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}$/;
         if (!emailRegex.test(email)) {
-          showMessage('warning', '이메일이 유효하지 않습니다.');
+          setMessageInfo({ type: 'warning', content: '이메일이 유효하지 않습니다.' });
           return;
         }
 
@@ -36,7 +37,7 @@ export default function PwInquiry() {
       }
 
       if (!email) {
-        showMessage('warning', '이메일을 입력해주세요.');
+        setMessageInfo({ type: 'warning', content: '이메일을 입력해주세요.' });
         return;
       }
     },
@@ -45,7 +46,6 @@ export default function PwInquiry() {
 
   return (
     <section className={'h-full'}>
-      {contextHolder}
       <div className={'w-h-full flex-col-center'}>
         <article>
           <img className={'w-[5.7rem] h-[6.7rem]'} src={'logo.svg'} alt={'logo'} />

--- a/src/pages/Member/SignUp.tsx
+++ b/src/pages/Member/SignUp.tsx
@@ -9,7 +9,6 @@ import {
   AiOutlineLock,
 } from 'react-icons/ai';
 import { convertMinutes } from '@/utils/convertMinutes.ts';
-import { useMessage } from '@/hooks/useMessage.ts';
 import { useMutation } from 'react-query';
 import { emailRequest, signUp } from '@/api/Members/Login-Signup.ts';
 import { EmailInfo, SignUpInfo } from '@/typings/member.ts';
@@ -17,6 +16,7 @@ import { useNavigate } from 'react-router-dom';
 import { loginStatus } from '@/recoil/User/atom.ts';
 import { useRecoilState } from 'recoil';
 import { sendLog } from '@/api/Log';
+import { message } from '@/recoil/Common/atom.ts';
 const time = 300;
 export default function SignUp() {
   const [name, onChangeName, setName] = useInput('');
@@ -33,7 +33,7 @@ export default function SignUp() {
   const [isEach, setIsEach] = useState(true);
   const [isPwVisible, setIsPwVisible] = useState(false);
   const [isCheckPw, setIsCheckPw] = useState(false);
-  const { showMessage, contextHolder } = useMessage();
+  const [messageInfo, setMessageInfo] = useRecoilState(message);
   const navigate = useNavigate();
   const [isLogin, setIsLogin] = useRecoilState(loginStatus);
   const [correctAuth, setCorrectAuth] = useState('');
@@ -50,7 +50,7 @@ export default function SignUp() {
   const { mutate, isSuccess } = useMutation(signUp, {
     onSuccess: (data) => {
       if (typeof data !== 'string' && 'message' in data) {
-        showMessage('warning', data.message);
+        setMessageInfo({ type: 'warning', content: data.message });
       } else {
         navigate('/login');
       }
@@ -72,7 +72,7 @@ export default function SignUp() {
     const emailInfo: EmailInfo = { email, type: 0 };
     emailMutate(emailInfo);
 
-    showMessage('success', '인증번호가 전송되었습니다.');
+    setMessageInfo({ type: 'success', content: '인증번호가 전송되었습니다.' });
     setTimer(time);
   }, [email]);
 
@@ -81,11 +81,11 @@ export default function SignUp() {
     // 인증이 되어있으면 return
     if (isAuth) return;
 
-    if (!email) return showMessage('warning', '이메일을 입력해주세요.');
+    if (!email) return setMessageInfo({ type: 'warning', content: '이메일을 입력해주세요.' });
 
     const emailRegex = /^[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}$/;
     if (!emailRegex.test(email)) {
-      showMessage('warning', '이메일이 유효하지 않습니다.');
+      setMessageInfo({ type: 'warning', content: '이메일이 유효하지 않습니다.' });
 
       return;
     }
@@ -102,9 +102,9 @@ export default function SignUp() {
 
     if (check) {
       setIsAuth(true);
-      showMessage('success', '인증되었습니다.');
+      setMessageInfo({ type: 'success', content: '인증되었습니다.' });
     } else {
-      showMessage('warning', '인증번호가 일치하지 않습니다.');
+      setMessageInfo({ type: 'warning', content: '인증번호가 일치하지 않습니다.' });
     }
   }, [isAuthClick, isAuth, email, correctAuth, auth]);
 
@@ -117,41 +117,41 @@ export default function SignUp() {
       e.preventDefault();
 
       if (!name && !nickname && !email && !isAuth && !isCheckPw) {
-        showMessage('warning', '모든 정보를 입력해주세요.');
+        setMessageInfo({ type: 'warning', content: '모든 정보를 입력해주세요.' });
 
         sendLogMutate({ page: 'singup', status: false, message: 'all' });
         return;
       }
 
       if (!name) {
-        showMessage('warning', '이름을 입력해주세요.');
+        setMessageInfo({ type: 'warning', content: '이름을 입력해주세요.' });
         sendLogMutate({ page: 'singup', status: false, message: 'name' });
         return;
       }
 
       if (!nickname) {
-        showMessage('warning', '닉네임을 입력해주세요.');
+        setMessageInfo({ type: 'warning', content: '닉네임을 입력해주세요.' });
         sendLogMutate({ page: 'singup', status: false, message: 'nickname' });
 
         return;
       }
 
       if (!emailRegex.test(email)) {
-        showMessage('warning', '이메일이 유효하지 않습니다.');
+        setMessageInfo({ type: 'warning', content: '이메일이 유효하지 않습니다.' });
         sendLogMutate({ page: 'signup', status: false, message: 'email' });
 
         return;
       }
 
       if (!isAuth) {
-        showMessage('warning', '인증번호 확인을 해주세요.');
+        setMessageInfo({ type: 'warning', content: '인증번호 확인을 해주세요.' });
         sendLogMutate({ page: 'signup', status: false, message: 'authNumber' });
 
         return;
       }
 
       if (!isCheckPw) {
-        showMessage('warning', '비밀번호를 확인 해주세요.');
+        setMessageInfo({ type: 'warning', content: '비밀번호를 확인 해주세요.' });
         sendLogMutate({ page: 'signup', status: false, message: 'password' });
 
         return;
@@ -197,7 +197,6 @@ export default function SignUp() {
 
   return (
     <form onSubmit={onSubmit} className={'h-full flex-col-center'}>
-      {contextHolder}
       <section
         className={'border-base w-[37rem] h-[42rem] min-h-[42rem] shadow-sign-up px-[4.5rem] py-4'}
       >

--- a/src/pages/Product/Members.tsx
+++ b/src/pages/Product/Members.tsx
@@ -11,7 +11,6 @@ import { IoMdClose } from 'react-icons/io';
 import { Scrollbars } from 'rc-scrollbars';
 import AuthorityModal from '@/components/Product/Members/AuthorityModal.tsx';
 import MemberListManageAlert from '@/components/Product/Members/MemberListManageAlert.tsx';
-import { useMessage } from '@/hooks/useMessage.ts';
 import { useMutation, useQueryClient } from 'react-query';
 import {
   changeProductMemberRole,
@@ -21,7 +20,7 @@ import {
 import { SaveUserInfo } from '@/typings/member.ts';
 import { useRecoilState, useRecoilValue } from 'recoil';
 import { productMemberList } from '@/recoil/Product/atom.ts';
-import { frontEndUrl } from '@/recoil/Common/atom.ts';
+import { frontEndUrl, message } from '@/recoil/Common/atom.ts';
 import { FaUserCircle } from 'react-icons/fa';
 import { sendLog } from '@/api/Log';
 import { useGetProductMembers } from '@/pages/Product/hooks/useGetProductMembers.ts';
@@ -44,7 +43,7 @@ export default function Members() {
   const baseUrl = useRecoilValue(frontEndUrl);
   // 방출인지 권한 위임인지
   const [isOut, setIsOut] = useState(false);
-  const { showMessage, contextHolder } = useMessage();
+  const [messageInfo, setMessageInfo] = useRecoilState(message);
   const [wrongEmail, setWrongEmail] = useState(0);
   const { mutate: sendLogMutate } = useMutation(sendLog);
 
@@ -64,31 +63,33 @@ export default function Members() {
           );
 
         if (failCnt > 0 && duplicatedCnt > 0) {
-          showMessage(
-            'error',
-            `${failMemberList.join(', ')}님 가입되어 있지 않고, ${duplicatedMemberList.join(
+          setMessageInfo({
+            type: 'error',
+            content: `${failMemberList.join(
               ', '
-            )}님은 이미 존재하여 초대에 실패했습니다.`
-          );
+            )}님 가입되어 있지 않고, ${duplicatedMemberList.join(
+              ', '
+            )}님은 이미 존재하여 초대에 실패했습니다.`,
+          });
           return;
         } else if (failCnt > 0) {
-          showMessage(
-            'error',
-            `${failMemberList.join(', ')}님은 가입되어 있지 않아 초대에 실패했습니다.`
-          );
+          setMessageInfo({
+            type: 'error',
+            content: `${failMemberList.join(', ')}님은 가입되어 있지 않아 초대에 실패했습니다.`,
+          });
 
           return;
         } else if (duplicatedCnt > 0) {
-          showMessage(
-            'error',
-            `${duplicatedMemberList.join(', ')}님은 이미 존재하여 초대에 실패했습니다.`
-          );
+          setMessageInfo({
+            type: 'error',
+            content: `${duplicatedMemberList.join(', ')}님은 이미 존재하여 초대에 실패했습니다.`,
+          });
 
           return;
         }
 
         location.reload();
-        showMessage('success', '성공적으로 초대되었습니다.');
+        setMessageInfo({ type: 'success', content: '성공적으로 초대되었습니다.' });
         setEmails('');
       }
     },
@@ -99,7 +100,7 @@ export default function Members() {
 
   const { mutate: changeProductMemberRoleMutate } = useMutation(changeProductMemberRole, {
     onSuccess: (data) => {
-      if (data) showMessage('error', '권한 변경에 실패하였습니다.');
+      if (data) setMessageInfo({ type: 'error', content: '권한 변경에 실패하였습니다.' });
     },
     onMutate: async ({ newPowerType, memberId }) => {
       await queryClient.cancelQueries(['getProductMemberList', productId]);
@@ -159,7 +160,7 @@ export default function Members() {
 
   const onClickInvite = useCallback(() => {
     if (emails === '') {
-      showMessage('warning', '이메일을 입력해주세요.');
+      setMessageInfo({ type: 'warning', content: '이메일을 입력해주세요.' });
       sendLogMutate({ page: 'member', status: false, message: 'all' });
 
       return;
@@ -184,7 +185,10 @@ export default function Members() {
       .filter((email) => email !== null) as string[];
 
     if (!isEmailFormat) {
-      showMessage('warning', '이메일 형식이 올바르지 않은 메일이 존재합니다.');
+      setMessageInfo({
+        type: 'warning',
+        content: '이메일 형식이 올바르지 않은 메일이 존재합니다.',
+      });
       return;
     }
 
@@ -275,7 +279,6 @@ export default function Members() {
       className={'w-full min-w-[50em] flex-col-center justify-start px-[30rem] py-14'}
       onClick={onCloseMemberKebab}
     >
-      {contextHolder}
       {(powerType === 'LEADER' || powerType === 'MASTER') && (
         <article className={'mb-20'}>
           <h1 className={'text-3xl font-bold mb-7'}>멤버 추가</h1>
@@ -436,7 +439,7 @@ export default function Members() {
         onClickChangeRoleLeader={onClickChangeRoleLeader}
         onClickChangeRoleDefault={onClickChangeRoleDefault}
         nowSelectedMemberId={nowSelectedMemberId}
-        showMessage={showMessage}
+        setMessageInfo={setMessageInfo}
       />
       <MemberListManageAlert
         isOut={isOut}
@@ -445,7 +448,7 @@ export default function Members() {
         nickName={nowSelectedMember}
         onClickChangeRoleLeader={onClickChangeRoleLeader}
         nowSelectedMemberId={nowSelectedMemberId}
-        showMessage={showMessage}
+        setMessageInfo={setMessageInfo}
       />
     </section>
   );

--- a/src/pages/Product/NewChangeLog.tsx
+++ b/src/pages/Product/NewChangeLog.tsx
@@ -9,18 +9,17 @@ import { formatDate } from '@/utils/formatDate.ts';
 import PostEditor from '@/components/Common/PostEditor.tsx';
 import { SaveUserInfo } from '@/typings/member.ts';
 import { Project } from '@/typings/project.ts';
-import { editorChangeLog } from '@/recoil/Common/atom.ts';
+import { editorChangeLog, message } from '@/recoil/Common/atom.ts';
 import { useRecoilState } from 'recoil';
 import { useMutation } from 'react-query';
 import { createNewChangeLog } from '@/api/Project/Version.ts';
-import { useMessage } from '@/hooks/useMessage.ts';
 import { user } from '@/recoil/User/atom.ts';
 
 const typeList: changeType[] = ['NEW', 'FEATURE', 'CHANGED', 'FIXED', 'DEPRECATED'];
 
 export default function NewChangeLog() {
   const { product } = useParams();
-  const { showMessage, contextHolder } = useMessage();
+  const [messageInfo, setMessageInfo] = useRecoilState(message);
   const [userInfo, setUserInfo] = useRecoilState(user);
   const nowProject: Project = JSON.parse(sessionStorage.getItem('nowProject')!);
   const [editChangeLog, setEditChangeLog] = useRecoilState(editorChangeLog);
@@ -47,14 +46,14 @@ export default function NewChangeLog() {
     {
       onSuccess: (data) => {
         if (typeof data !== 'string' && 'projectId' in data) {
-          showMessage('success', '변경사항이 성공적으로 등록되었습니다.');
+          setMessageInfo({ type: 'success', content: '변경사항이 성공적으로 등록되었습니다.' });
           setTimeout(() => {
             history.back();
           }, 2000);
         } else if (typeof data !== 'string' && 'message' in data) {
-          showMessage('warning', data.message);
+          setMessageInfo({ type: 'warning', content: data.message });
         } else {
-          showMessage('error', '변경사항 등록에 실패하였습니다.');
+          setMessageInfo({ type: 'error', content: '변경사항 등록에 실패하였습니다.' });
         }
       },
     }
@@ -62,11 +61,11 @@ export default function NewChangeLog() {
 
   const onClickCreate = useCallback(() => {
     if (title === '') {
-      showMessage('warning', '변경사항 제목을 입력해주세요.');
+      setMessageInfo({ type: 'warning', content: '변경사항 제목을 입력해주세요.' });
       return;
     }
     if (editChangeLog === '') {
-      showMessage('warning', '변경사항 내용을 입력해주세요.');
+      setMessageInfo({ type: 'warning', content: '변경사항 내용을 입력해주세요.' });
       return;
     }
     setNewChangeLog({
@@ -98,7 +97,6 @@ export default function NewChangeLog() {
 
   return (
     <section className={'w-full h-auto flex py-20'}>
-      {contextHolder}
       <article className={'pt-4 flex justify-center w-[10%] min-w-[6rem] lg:w-[16%]'}>
         <Link
           to={`/workspace/${product}`}

--- a/src/pages/Product/ReleaseNote.tsx
+++ b/src/pages/Product/ReleaseNote.tsx
@@ -10,9 +10,9 @@ import { useQueries, useQuery } from 'react-query';
 import { getAllProductProjects, getChangeLogEachProject } from '@/api/Project/Version.ts';
 import { useRecoilState } from 'recoil';
 import { eachProductProjects } from '@/recoil/Project/atom.ts';
-import { useMessage } from '@/hooks/useMessage.ts';
 import { BiPencil } from 'react-icons/bi';
 import { FaUserCircle } from 'react-icons/fa';
+import { message } from '@/recoil/Common/atom.ts';
 export default function ReleaseNote() {
   // const dummy: Release[] = [
   //   {
@@ -111,7 +111,7 @@ export default function ReleaseNote() {
   const { state } = useLocation();
   const [isLogin, setIsLogin] = useState(state?.isLogin);
   const [productList, refetch] = useGetAllProduct(false)!;
-  const { showMessage, contextHolder } = useMessage();
+  const [messageInfo, setMessageInfo] = useRecoilState(message);
   const { pathname } = useLocation();
 
   const { isOpen, onOpen, onClose } = useDisclosure();
@@ -197,7 +197,6 @@ export default function ReleaseNote() {
 
   return (
     <section className={'w-full min-w-[50em] py-32 px-14 xl:px-56'} onClick={onCloseKebab}>
-      {contextHolder}
       <div className={'min-w-[30em] flex justify-between mb-4'}>
         <span className={'flex items-center'}>
           {nowProduct?.productImage ? (
@@ -211,7 +210,7 @@ export default function ReleaseNote() {
           className={'mr-2 text-gray-dark font-bold underline self-end'}
           onClick={() => {
             if (projects?.[0].projectStatus === 'PROGRESS_IN') {
-              showMessage('warning', '현재 진행 중인 프로젝트가 있습니다.');
+              setMessageInfo({ type: 'warning', content: '현재 진행 중인 프로젝트가 있습니다.' });
               return;
             }
 
@@ -292,7 +291,7 @@ export default function ReleaseNote() {
         onClose={onClose}
         isAdd={isAdd}
         versionName={tempVersion}
-        showMessage={showMessage}
+        setMessageInfo={setMessageInfo}
         nowProjectId={nowProjectId}
       />
     </section>

--- a/src/pages/Project/TaskDetail.tsx
+++ b/src/pages/Project/TaskDetail.tsx
@@ -10,11 +10,11 @@ import { TaskStatus, UpdateTaskBody } from '@/typings/task.ts';
 import DeleteDialog from '@/components/Common/DeleteDialog.tsx';
 import { eachTask, editTask } from '@/api/Project/Task.ts';
 import { useMutation, useQuery, useQueryClient } from 'react-query';
-import { useMessage } from '@/hooks/useMessage.ts';
 import { checkTaskEditValue } from '@/utils/checkTaskEditValue.ts';
 import { useRecoilState } from 'recoil';
 import { eachTaskInfo, editTaskInfo } from '@/recoil/Project/Task.ts';
 import { SaveProjectInfo } from '@/typings/project.ts';
+import { message } from '@/recoil/Common/atom.ts';
 
 export default function TaskDetail() {
   const nowProject: SaveProjectInfo = JSON.parse(sessionStorage.getItem('nowProject')!);
@@ -22,7 +22,7 @@ export default function TaskDetail() {
   // const { product, project, menutitle, taskid } = useParams();
   const { taskid } = useParams();
   const { isOpen, onOpen, onClose } = useDisclosure();
-  const { showMessage, contextHolder } = useMessage();
+  const [messageInfo, setMessageInfo] = useRecoilState(message);
   const [editSuccess, setEditSuccess] = useState<boolean>(true);
   const queryClient = useQueryClient();
 
@@ -59,9 +59,9 @@ export default function TaskDetail() {
     {
       onSuccess: (data) => {
         if (typeof data === 'object' && 'message' in data) {
-          showMessage('warning', data.message);
+          setMessageInfo({ type: 'warning', content: data.message });
         } else if (typeof data === 'object' && 'id' in data) {
-          showMessage('success', 'Task 수정에 성공했습니다.');
+          setMessageInfo({ type: 'success', content: 'Task 수정에 성공했습니다.' });
         }
       },
       onSettled: () => {
@@ -81,18 +81,18 @@ export default function TaskDetail() {
     const checkEmpty = checkTaskEditValue(editTaskData);
 
     if (!checkEmpty) {
-      showMessage('warning', 'Task의 정보를 모두 작성해주세요');
+      setMessageInfo({ type: 'warning', content: 'Task의 정보를 모두 작성해주세요' });
       return;
     }
 
     editTaskMutate(editTaskData);
 
     // if (!editSuccess) {
-    //   showMessage('error', 'Task 수정에 실패했습니다.');
+    // setMessageInfo({ type: 'error', content: 'Task 수정에 실패했습니다.' });
     //   return;
     // }
     //
-    // showMessage('success', 'Task 수정에 성공했습니다.');
+    // setMessageInfo('success', 'Task 수정에 성공했습니다.');
     setTimeout(() => onClose(), 2000);
     setIsEdit(false);
   }, [isEdit, editTaskData, editSuccess]);
@@ -128,7 +128,6 @@ export default function TaskDetail() {
 
   return (
     <section className={'flex w-full h-auto py-20'}>
-      {contextHolder}
       {/*돌아가기 버튼*/}
       <article className={'pt-4 flex justify-center w-[10%] min-w-[6rem] lg:w-[16%]'}>
         <div className={'flex justify-center text-[1.3rem] text-gray-dark font-bold'}>

--- a/src/recoil/Common/atom.ts
+++ b/src/recoil/Common/atom.ts
@@ -1,4 +1,5 @@
 import { atom } from 'recoil';
+type MessageType = 'success' | 'error' | 'warning';
 
 export const themeState = atom<boolean>({
   key: 'themeState',
@@ -21,4 +22,10 @@ const DEPLOYMENT_FRONTEND_URL = import.meta.env.VITE_DEPLOYMENT_FRONTEND_URL;
 export const frontEndUrl = atom<string>({
   key: 'frontEndUrl',
   default: isDeployment ? DEPLOYMENT_FRONTEND_URL : DEV_FRONTEND_URL,
+});
+
+// message 중앙화
+export const message = atom<{ type: MessageType; content: string } | null>({
+  key: 'message',
+  default: null,
 });


### PR DESCRIPTION
## PR Checklist
아래 요구사항을 만족하는지 체크:

- [ ] 작성한 코드에 대한 테스트 코드 작성 (기능 추가 / 버그 개선)
- [ ] 작성한 코드 문서화 (기능 추가 / 버그 개선)


## PR Type
해당 PR이 포함하는 내용 체크:

- [ ] 패키지
  - [ ] 패키지 추가
  - [ ] 패키지 설정 변경
- [ ] CI
  - [ ] CI 구성 추가
  - [ ] CI 설정 변경
- [ ] 문서화
  - [ ] 신규 문서 추가
  - [ ] 기존 문서 변경
- [ ] 신규 기능 추가
- [ ] 버그 수정
- [x] 코드 개선
  - [ ] 성능 개선
  - [x] UI 개선
  - [ ] 성능에 영향을 끼치지 않는 수정
- [ ] 테스트
  - [ ] 테스트 코드 추가
  - [ ] 기존 테스트 코드 변경
- [ ] 커밋 되돌리기
- [ ] 기타


## 해당 PR에 대한 설명
antd Message를 Header.tsx에 중앙화 했음

-설명
useMessage는 Header.tsx에서만 사용

recoil/Common/atom.tsx에 message를 생성 -> 기존 useMessage를 사용하던 컴포넌트들은 message 아톰에 값을 전달하는 것으로 변경 -> Header에서 message atom을 구독했다가 변경이 감지되면 Message 띄워줌

## 스크린샷
-바꾸기 전 
![image](https://github.com/GAK-coding/UpLog-frontEnd/assets/86971770/0e59a282-ce34-4839-8f42-47a8a47f7865)

-바꾼 후
![image](https://github.com/GAK-coding/UpLog-frontEnd/assets/86971770/4d6e2d16-e917-42df-90c7-03d29027f0b9)


## 기타 정보